### PR TITLE
Unify the owner workspace shell

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -394,7 +394,11 @@ export function App() {
 
       if (event.key === "Escape") {
         setCommandOpen(false);
-        closeReader();
+        if (filtersOpen) {
+          setFiltersOpen(false);
+        } else {
+          closeReader();
+        }
         return;
       }
 
@@ -420,7 +424,7 @@ export function App() {
 
     window.addEventListener("keydown", handleShortcut);
     return () => window.removeEventListener("keydown", handleShortcut);
-  }, [busyAction, undoNotice]);
+  }, [busyAction, filtersOpen, undoNotice, view]);
 
   // Pasting a URL with nothing focused stages it in the omnibar and puts the
   // caret there. It stops short of saving: writing an item straight from the
@@ -544,7 +548,7 @@ export function App() {
         (tag) =>
           !normalizedSearch || tag.toLocaleLowerCase().includes(normalizedSearch),
       )
-      .slice(0, 50);
+      .slice(0, normalizedSearch ? 20 : 8);
   }, [knownTags, selectedTags, tagSearch]);
   const appliedFilterCount =
     Number(filter !== "active") +
@@ -594,6 +598,7 @@ export function App() {
     if (nextUrl !== currentUrl) {
       window.history.pushState(window.history.state, "", nextUrl);
     }
+    setReaderItem(null);
     setView(nextView);
   }
 
@@ -876,11 +881,11 @@ export function App() {
     setEditingItem(item);
   }
 
-  function openReader(item: LibraryItemView, replace = false) {
+  function openReader(item: LibraryItemView) {
     const nextUrl = `${window.location.pathname}${window.location.search}#item=${encodeURIComponent(item.id)}`;
     const nextState = { ...window.history.state, researchPocketReader: true };
-    if (replace) window.history.replaceState(nextState, "", nextUrl);
-    else window.history.pushState(nextState, "", nextUrl);
+    window.history.pushState(nextState, "", nextUrl);
+    setView("library");
     setReaderItem(item);
   }
 
@@ -945,20 +950,13 @@ export function App() {
   const repositoryError = readStateError(libraryState.error);
   const displayedError = localError ?? repositoryError;
 
-  /**
-   * The two pushed screens — an open document and an open save — share one
-   * shell: the way back sits in the brand slot, the sync chip stays put, and
-   * the content column below is the only thing that differs. On a phone that
-   * back button is the only one there is.
-   */
-  const pushedScreen = readerItem
-    ? { label: "Library", onBack: closeReader }
-    : openZen
-      ? { label: "Zen", onBack: closeZenDocument }
-      : null;
-  // The rail is a library-and-Zen control strip. Elsewhere, and under a pushed
-  // screen, it has nothing to say and an empty strip reads as a fault.
-  const railApplies = (view === "library" || view === "zen") && !pushedScreen;
+  // A Zen document remains a focused writing surface. Saved items, Sync, and
+  // Settings all use the normal workspace shell so navigation does not change
+  // shape as the owner moves through the application.
+  const pushedScreen = openZen
+    ? { label: "Zen", onBack: closeZenDocument }
+    : null;
+  const railApplies = !openZen;
 
   if (libraryState.loading) {
     return <BootScreen />;
@@ -995,27 +993,21 @@ export function App() {
                 <span>{pushedScreen.label}</span>
               </button>
             ) : null}
-            {/* Ahead of the wordmark, where the design puts it: the control
-                belongs to the panel it opens, not to the brand. */}
+            {/* The sidebar control leads the brand as part of one compact
+                header cluster; it is not positioned against the rail seam. */}
             {railApplies ? (
               <button
                 aria-controls="workspace-sidebar"
                 aria-expanded={!railCollapsed}
+                aria-label={railCollapsed ? "Show sidebar" : "Hide sidebar"}
                 className="workspace-rail-toggle"
                 onClick={() => setRailCollapsed((collapsed) => !collapsed)}
                 title={railCollapsed ? "Show sidebar" : "Hide sidebar"}
                 type="button"
               >
-                {/* Three rules rather than the word "sidebar": the button sits
-                    beside the wordmark, where a second label competes with it. */}
-                <span aria-hidden="true" className="rail-toggle-glyph">
-                  <span />
-                  <span />
-                  <span />
-                </span>
-                <span className="sr-only">
-                  {railCollapsed ? "Show sidebar" : "Hide sidebar"}
-                </span>
+                <svg aria-hidden="true" viewBox="0 0 20 20">
+                  <path d="M3 5.5h14M3 10h14M3 14.5h14" />
+                </svg>
               </button>
             ) : null}
             <button
@@ -1185,6 +1177,16 @@ export function App() {
             <span aria-hidden="true" className="rail-glyph-spacer" />
 
             <button
+              aria-current={view === "sync" ? "page" : undefined}
+              className="rail-glyph-quiet"
+              onClick={() => navigateToView("sync")}
+              title="Sync"
+              type="button"
+            >
+              <span aria-hidden="true">↻</span>
+              <span className="sr-only">Sync</span>
+            </button>
+            <button
               aria-current={view === "settings" ? "page" : undefined}
               className="rail-glyph-quiet"
               onClick={() => navigateToView("settings")}
@@ -1287,7 +1289,11 @@ export function App() {
                 <button
                   aria-controls="library-filters"
                   aria-expanded={filtersOpen}
-                  onClick={() => setFiltersOpen((open) => !open)}
+                  onClick={() => {
+                    const toggleInPlace = view === "library" && readerItem === null;
+                    navigateToView("library");
+                    setFiltersOpen(toggleInPlace ? !filtersOpen : true);
+                  }}
                   type="button"
                 >
                   {appliedFilterCount > 0
@@ -1311,18 +1317,12 @@ export function App() {
               </div>
             </div>
 
-            <button
-              aria-controls="library-filters"
-              aria-expanded={filtersOpen}
-              className="mobile-tag-filter-trigger"
-              onClick={() => setFiltersOpen(true)}
-              type="button"
-            >
-              Filters{appliedFilterCount > 0 ? ` · ${appliedFilterCount}` : ""}
-            </button>
-
             <nav aria-label="Workspace utilities" className="rail-utilities">
-              <button onClick={() => navigateToView("sync")} type="button">
+              <button
+                aria-current={view === "sync" ? "page" : undefined}
+                onClick={() => navigateToView("sync")}
+                type="button"
+              >
                 <span>Sync</span><small>{libraryState.pendingCount} pending</small>
               </button>
               <button
@@ -1339,10 +1339,21 @@ export function App() {
         <main id="workspace" tabIndex={-1}>
           <h1 className="sr-only">ResearchPocket owner library</h1>
 
+        {readerItem ? (
+          <ReaderView
+            busy={busyAction !== null}
+            item={items.find((item) => item.id === readerItem.id) ?? readerItem}
+            onBack={closeReader}
+            onDelete={deleteItem}
+            onEdit={openEditor}
+            onFavorite={toggleFavorite}
+          />
+        ) : null}
+
         <SyncPanel
           activeItemIds={new Set(items.filter((item) => !item.deleted).map((item) => item.id))}
           busy={busyAction !== null}
-          hidden={view !== "sync"}
+          hidden={view !== "sync" || readerItem !== null}
           onDeletePendingItem={(itemId) => {
             const item = items.find((candidate) => candidate.id === itemId);
             if (item && !item.deleted) void deleteItem(item);
@@ -1354,7 +1365,7 @@ export function App() {
         <SettingsPanel
           activeProfileId={activeProfileId}
           density={density}
-          hidden={view !== "settings"}
+          hidden={view !== "settings" || readerItem !== null}
           imageBackground={imageBackground}
           onDensityChange={setDensity}
           onImageBackgroundChange={setImageBackground}
@@ -1368,7 +1379,7 @@ export function App() {
         <ZenWorkspace
           busy={busyAction !== null}
           documents={zenDocuments}
-          hidden={view !== "zen"}
+          hidden={view !== "zen" || readerItem !== null}
           onClose={closeZenDocument}
           onCreate={(title) => void createZenDocument(title)}
           onDelete={(documentId) => void removeZenDocument(documentId)}
@@ -1384,7 +1395,7 @@ export function App() {
           aria-busy={searchPending}
           aria-labelledby="library-heading"
           className="library-section"
-          hidden={view !== "library"}
+          hidden={view !== "library" || readerItem !== null}
           id="library"
         >
           <div className="library-heading-row">
@@ -1431,88 +1442,121 @@ export function App() {
             </div>
           </div>
 
-          <Omnibar
-            busy={busyAction !== null}
-            onAdd={addItem}
-            onQueryChange={setQuery}
-            query={query}
-          />
+          <div className="library-search-row">
+            <Omnibar
+              busy={busyAction !== null}
+              onAdd={addItem}
+              onQueryChange={setQuery}
+              query={query}
+            />
+            <button
+              aria-controls="library-filters"
+              aria-expanded={filtersOpen}
+              className="filter-trigger"
+              onClick={() => setFiltersOpen((open) => !open)}
+              type="button"
+            >
+              <svg aria-hidden="true" viewBox="0 0 20 20">
+                <path d="M3 5h14M6 10h8M8.5 15h3" />
+              </svg>
+              <span>Filters</span>
+              {appliedFilterCount > 0 ? (
+                <span className="filter-trigger-count">{appliedFilterCount}</span>
+              ) : null}
+            </button>
+          </div>
 
-          <div className="library-filters" hidden={!filtersOpen} id="library-filters">
-            <div className="filter-heading">
-              <strong>Filter library</strong>
-              <button onClick={() => setFiltersOpen(false)} type="button">Done</button>
+          <div
+            aria-label="Library filters"
+            className="library-filters"
+            hidden={!filtersOpen}
+            id="library-filters"
+            role="region"
+          >
+            <div className="filter-controls">
+              <label>
+                <select
+                  aria-label="Search fields"
+                  id="search-scope"
+                  name="search-scope"
+                  onChange={(event) => setSearchScope(event.target.value as SearchScope)}
+                  value={searchScope}
+                >
+                  <option value="all">All fields</option>
+                  <option value="title">Title</option>
+                  <option value="url">URL</option>
+                  <option value="context">Context</option>
+                  <option value="tags">Tags</option>
+                </select>
+              </label>
+              <label>
+                <select
+                  aria-label="Item state"
+                  id="lifecycle-filter"
+                  name="lifecycle-filter"
+                  onChange={(event) => setFilter(event.target.value as LifecycleFilter)}
+                  value={filter}
+                >
+                  <option value="active">Active {activeCount}</option>
+                  <option value="deleted">Deleted {deletedCount}</option>
+                  <option value="all">All {items.length}</option>
+                </select>
+              </label>
+              <label>
+                <select
+                  aria-label="Sort order"
+                  id="sort-mode"
+                  name="sort-mode"
+                  onChange={(event) => setSortMode(event.target.value as SortMode)}
+                  value={sortMode}
+                >
+                  <option value="recent">Newest</option>
+                  <option value="oldest">Oldest</option>
+                  <option value="title">Title</option>
+                </select>
+              </label>
+              <label className="filter-favorite">
+                <input
+                  checked={favoriteOnly}
+                  id="favorite-filter"
+                  name="favorite-filter"
+                  onChange={(event) => setFavoriteOnly(event.target.checked)}
+                  type="checkbox"
+                />
+                <span>Favorites</span>
+              </label>
+              <div className="filter-actions">
+                {appliedFilterCount > 0 ? (
+                  <button
+                    className="filter-reset"
+                    onClick={() => {
+                      setFilter("active");
+                      setSearchScope("all");
+                      setFavoriteOnly(false);
+                      setSelectedTags([]);
+                      setTagSearch("");
+                      setTagMatchMode("all");
+                      setSortMode("recent");
+                    }}
+                    type="button"
+                  >
+                    Clear
+                  </button>
+                ) : null}
+                <button
+                  aria-label="Close filters"
+                  className="filter-close"
+                  onClick={() => setFiltersOpen(false)}
+                  title="Close filters"
+                  type="button"
+                >
+                  <span aria-hidden="true">×</span>
+                </button>
+              </div>
             </div>
-            <label>
-              <select
-                aria-label="Search fields"
-                id="search-scope"
-                name="search-scope"
-                onChange={(event) => setSearchScope(event.target.value as SearchScope)}
-                value={searchScope}
-              >
-                <option value="all">All fields</option>
-                <option value="title">Title</option>
-                <option value="url">URL</option>
-                <option value="context">Context</option>
-                <option value="tags">Tags</option>
-              </select>
-            </label>
-            <label>
-              <select
-                aria-label="Item state"
-                id="lifecycle-filter"
-                name="lifecycle-filter"
-                onChange={(event) => setFilter(event.target.value as LifecycleFilter)}
-                value={filter}
-              >
-                <option value="active">Active {activeCount}</option>
-                <option value="deleted">Deleted {deletedCount}</option>
-                <option value="all">All {items.length}</option>
-              </select>
-            </label>
-            <label>
-              <select
-                aria-label="Sort order"
-                id="sort-mode"
-                name="sort-mode"
-                onChange={(event) => setSortMode(event.target.value as SortMode)}
-                value={sortMode}
-              >
-                <option value="recent">Newest</option>
-                <option value="oldest">Oldest</option>
-                <option value="title">Title</option>
-              </select>
-            </label>
-            <label className="filter-favorite">
-              <input
-                checked={favoriteOnly}
-                id="favorite-filter"
-                name="favorite-filter"
-                onChange={(event) => setFavoriteOnly(event.target.checked)}
-                type="checkbox"
-              />
-              <span>Favorites only</span>
-            </label>
-            {appliedFilterCount > 0 ? (
-              <button
-                className="filter-reset"
-                onClick={() => {
-                  setFilter("active");
-                  setSearchScope("all");
-                  setFavoriteOnly(false);
-                  setSelectedTags([]);
-                  setTagSearch("");
-                  setTagMatchMode("all");
-                  setSortMode("recent");
-                }}
-                type="button"
-              >
-                Reset
-              </button>
-            ) : null}
             {knownTags.length > 0 ? (
               <fieldset aria-label="Tag filters" className="tag-filter-group">
+                <legend className="sr-only">Tags</legend>
                 <label className="tag-filter-search">
                   <input
                     aria-label="Find tags"
@@ -1520,7 +1564,7 @@ export function App() {
                     id="tag-filter-search"
                     name="tag-filter-search"
                     onChange={(event) => setTagSearch(event.target.value)}
-                    placeholder="Add tag filter"
+                    placeholder="Find a tag…"
                     type="search"
                     value={tagSearch}
                   />
@@ -1661,7 +1705,7 @@ export function App() {
         {/* Zen moved into the chip strip, so this keeps only what the strip and
             the omnibar cannot carry: an authored capture, and Settings. It is
             gone entirely under a pushed screen, which has its own footer. */}
-        {pushedScreen ? null : (
+        {pushedScreen || readerItem ? null : (
           <nav aria-label="Mobile actions" className="mobile-actions">
             <button className="primary-button" onClick={(event) => openCapture(event.currentTarget)} type="button">＋ Save a link</button>
             <button className="secondary-button" onClick={() => navigateToView("settings")} type="button">Settings</button>
@@ -1778,18 +1822,6 @@ export function App() {
         />
       ) : null}
 
-      {readerItem ? (
-        <ReaderView
-          busy={busyAction !== null}
-          item={items.find((item) => item.id === readerItem.id) ?? readerItem}
-          items={visibleItems}
-          onBack={closeReader}
-          onDelete={deleteItem}
-          onEdit={openEditor}
-          onFavorite={toggleFavorite}
-          onSelect={(item) => openReader(item, true)}
-        />
-      ) : null}
     </div>
   );
 }
@@ -2248,45 +2280,127 @@ function SyncPanel({
       hidden={hidden}
     >
       <header className="sync-header">
-        <p className="eyebrow">Remote</p>
-        <h2 id="sync-heading">Private sync</h2>
-        <p>Exchange updates through one private GitHub repository.</p>
+        <div>
+          <h2 id="sync-heading">Sync</h2>
+          <p>Private GitHub repository</p>
+        </div>
+        <div className="sync-state" role="status">
+          <span aria-hidden="true" className="status-dot" />
+          <span>{state.status}</span>
+        </div>
       </header>
 
-      <div className="sync-state" role="status">
-        <span aria-hidden="true" className="status-dot" />
-        <span>{state.status}</span>
-      </div>
+      <div className="sync-layout">
+        <section aria-labelledby="sync-connection-heading" className="sync-connection">
+          <div className="sync-panel-heading">
+            <h3 id="sync-connection-heading">
+              {remote ? "Connection" : "Connect GitHub"}
+            </h3>
+            {remote ? <span>{remote.owner}/{remote.repository}</span> : null}
+          </div>
 
-      {remote ? (
-        <dl className="sync-facts">
-          <div>
-            <dt>Repository</dt>
-            <dd>{remote.owner}/{remote.repository}</dd>
-          </div>
-          <div>
-            <dt>Branch</dt>
-            <dd>{remote.branch}</dd>
-          </div>
-          <div>
-            <dt>Last sync</dt>
-            <dd>
-              {remote.lastSuccessAt ? formatDateTime(remote.lastSuccessAt) : "Never"}
-            </dd>
-          </div>
-          {state.lastCycle ? (
-            <div>
-              <dt>Last cycle</dt>
-              <dd>
-                {state.lastCycle.downloaded + state.lastCycle.aggregatesApplied} down ·{" "}
-                {state.lastCycle.uploaded + state.lastCycle.aggregatesUploaded} up
-              </dd>
-            </div>
+          {remote ? (
+            <dl className="sync-facts">
+              <div>
+                <dt>Repository</dt>
+                <dd>{remote.owner}/{remote.repository}</dd>
+              </div>
+              <div>
+                <dt>Branch</dt>
+                <dd>{remote.branch}</dd>
+              </div>
+              <div>
+                <dt>Last sync</dt>
+                <dd>
+                  {remote.lastSuccessAt ? formatDateTime(remote.lastSuccessAt) : "Never"}
+                </dd>
+              </div>
+              {state.lastCycle ? (
+                <div>
+                  <dt>Last cycle</dt>
+                  <dd>
+                    {state.lastCycle.downloaded + state.lastCycle.aggregatesApplied} down ·{" "}
+                    {state.lastCycle.uploaded + state.lastCycle.aggregatesUploaded} up
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
           ) : null}
-        </dl>
-      ) : null}
 
-      <div className="sync-content">
+          {!remote ? (
+            <form className="sync-form" onSubmit={(event) => void connect(event)}>
+              <div className="sync-repository-fields">
+                <label className="field">
+                  <span>Private repository</span>
+                  <input
+                    autoCapitalize="none"
+                    autoComplete="off"
+                    id="sync-repository"
+                    name="repository"
+                    onChange={(event) => setRepository(event.target.value)}
+                    placeholder="owner/private-repository"
+                    required
+                    spellCheck={false}
+                    value={repository}
+                  />
+                </label>
+                <label className="field">
+                  <span>Branch <small>optional</small></span>
+                  <input
+                    autoCapitalize="none"
+                    autoComplete="off"
+                    id="sync-branch"
+                    name="branch"
+                    onChange={(event) => setBranch(event.target.value)}
+                    placeholder="main"
+                    spellCheck={false}
+                    value={branch}
+                  />
+                </label>
+              </div>
+              <TokenFields />
+              {error ? <p className="sync-error" role="alert">{error}</p> : null}
+              <button className="primary-button" disabled={state.syncing} type="submit">
+                {state.syncing ? "Connecting…" : "Connect"}
+              </button>
+            </form>
+          ) : !state.credentialAvailable ? (
+            <form className="sync-form" onSubmit={(event) => void unlock(event)}>
+              <p className="sync-connection-note">
+                Repository saved. Enter the token again to pull and push.
+              </p>
+              <TokenFields />
+              {error ? <p className="sync-error" role="alert">{error}</p> : null}
+              <button className="primary-button" disabled={state.syncing} type="submit">
+                {state.syncing ? "Synchronizing…" : "Unlock and sync"}
+              </button>
+            </form>
+          ) : (
+            <div className="sync-controls">
+              <p>Token available only in this browser context.</p>
+              {error ? <p className="sync-error" role="alert">{error}</p> : null}
+              <div className="sync-actions">
+                <button
+                  className="primary-button"
+                  disabled={state.syncing}
+                  onClick={() => void syncNow()}
+                  type="button"
+                >
+                  {state.syncing ? "Synchronizing…" : "Sync now"}
+                </button>
+                <button
+                  className="secondary-button"
+                  disabled={state.syncing}
+                  onClick={() => browserSync.forgetCredential()}
+                  type="button"
+                >
+                  Forget token
+                </button>
+              </div>
+            </div>
+          )}
+        </section>
+
         <PendingSyncChanges
           activeItemIds={activeItemIds}
           changes={pendingChanges}
@@ -2295,81 +2409,6 @@ function SyncPanel({
           onDeleteItem={onDeletePendingItem}
           syncing={state.syncing}
         />
-
-        {!remote ? (
-          <form className="sync-form" onSubmit={(event) => void connect(event)}>
-            <label className="field">
-              <span>Private data repository</span>
-              <input
-                autoCapitalize="none"
-                autoComplete="off"
-                id="sync-repository"
-                name="repository"
-                onChange={(event) => setRepository(event.target.value)}
-                placeholder="owner/private-repository"
-                required
-                spellCheck={false}
-                value={repository}
-              />
-            </label>
-            <label className="field">
-              <span>Branch <small>default branch when blank</small></span>
-              <input
-                autoCapitalize="none"
-                autoComplete="off"
-                id="sync-branch"
-                name="branch"
-                onChange={(event) => setBranch(event.target.value)}
-                placeholder="main"
-                spellCheck={false}
-                value={branch}
-              />
-            </label>
-            <TokenFields />
-            {error ? <p className="sync-error" role="alert">{error}</p> : null}
-            <button className="primary-button" disabled={state.syncing} type="submit">
-              {state.syncing ? "Connecting…" : "Connect private sync"}
-            </button>
-          </form>
-        ) : !state.credentialAvailable ? (
-          <form className="sync-form" onSubmit={(event) => void unlock(event)}>
-            <p>
-              The repository is remembered on this device; the token is not. Enter
-              it again to pull and push queued changes.
-            </p>
-            <TokenFields />
-            {error ? <p className="sync-error" role="alert">{error}</p> : null}
-            <button className="primary-button" disabled={state.syncing} type="submit">
-              {state.syncing ? "Synchronizing…" : "Unlock and sync"}
-            </button>
-          </form>
-        ) : (
-          <div className="sync-controls">
-            <p>
-              The token stays in this browser context only. It never enters the
-              library, a URL, or the service-worker cache.
-            </p>
-            {error ? <p className="sync-error" role="alert">{error}</p> : null}
-            <div className="sync-actions">
-              <button
-                className="primary-button"
-                disabled={state.syncing}
-                onClick={() => void syncNow()}
-                type="button"
-              >
-                {state.syncing ? "Synchronizing…" : "Sync now"}
-              </button>
-              <button
-                className="secondary-button"
-                disabled={state.syncing}
-                onClick={() => browserSync.forgetCredential()}
-                type="button"
-              >
-                Forget token
-              </button>
-            </div>
-          </div>
-        )}
       </div>
     </section>
   );
@@ -2397,11 +2436,11 @@ function PendingSyncChanges({
       className="sync-pending"
     >
       <div className="sync-pending-heading">
-        <h3 id="sync-pending-heading">Local changes waiting</h3>
+        <h3 id="sync-pending-heading">Pending</h3>
         <span>{pluralize(changes.length, "change")}</span>
       </div>
       <p className="sync-pending-help">
-        Outgoing changes stay on this device until GitHub confirms them.
+        Kept locally until GitHub confirms them.
       </p>
 
       {changes.length > 0 ? (
@@ -2431,8 +2470,8 @@ function PendingSyncChanges({
       ) : (
         <p className="sync-pending-empty">
           {hasSynced
-            ? "Everything from this browser is synced."
-            : "No local changes are waiting to sync."}
+            ? "Everything is synced."
+            : "No changes waiting."}
         </p>
       )}
     </section>
@@ -2460,11 +2499,10 @@ function TokenFields() {
           name="remember-for-tab"
           type="checkbox"
         />
-        <span>Keep the token only for this tab session</span>
+        <span>Keep token for this tab</span>
       </label>
       <p className="sync-help">
-        Use an expiring fine-grained token limited to this repository, with
-        Contents read and write. Leave the box off to keep it in memory only.
+        Expiring fine-grained token · this repository only · Contents read/write.
       </p>
     </>
   );
@@ -2791,21 +2829,17 @@ function CommandPalette({
 function ReaderView({
   busy,
   item,
-  items,
   onBack,
   onDelete,
   onEdit,
   onFavorite,
-  onSelect,
 }: {
   busy: boolean;
   item: LibraryItemView;
-  items: LibraryItemView[];
   onBack: () => void;
   onDelete: (item: LibraryItemView) => Promise<void>;
   onEdit: (item: LibraryItemView, opener: HTMLButtonElement) => void;
   onFavorite: (item: LibraryItemView) => Promise<void>;
-  onSelect: (item: LibraryItemView) => void;
 }) {
   const [itemsWithImages, setItemsWithImages] = useState<Set<string>>(
     () => new Set(),
@@ -2893,56 +2927,57 @@ function ReaderView({
   }
 
   return (
-    <div className="reader-view" role="dialog" aria-modal="true" aria-labelledby="reader-title">
-      <aside className="reader-list">
-        <header><button onClick={onBack} type="button">← All saves</button><span>{items.length}</span></header>
-        <ol>
-          {items.map((candidate) => (
-            <li className={candidate.id === item.id ? "reader-selected" : undefined} key={candidate.id}>
-              <button onClick={() => onSelect(candidate)} type="button">
-                <strong>{candidate.title?.trim() || candidate.url}</strong>
-                <span>{readHostname(candidate.url)} · {formatDate(candidate.savedAt)}</span>
-              </button>
-            </li>
-          ))}
-        </ol>
-        <footer><span><b>j/k</b> next</span><span><b>esc</b> back</span></footer>
-      </aside>
+    <section className="reader-view" aria-labelledby="reader-title">
       <article className="reader-article">
-        {/* The pushed-screen title bar. Back sits in the masthead above it, so
-            this row carries the title and the two things a reader does to a
-            save without leaving it. */}
-        <header className="reader-mobile-header">
-          <span className="reader-mobile-title">{label}</span>
-          <button
-            aria-label={item.favorite ? "Remove favorite" : "Favorite"}
-            aria-pressed={item.favorite}
-            className="icon-button"
-            disabled={busy}
-            onClick={() => void onFavorite(item)}
-            type="button"
-          >
-            <span aria-hidden="true">★</span>
+        <header className="reader-toolbar">
+          <button className="reader-back" onClick={onBack} type="button">
+            <span aria-hidden="true">←</span>
+            <span>All saves</span>
           </button>
-          <a
-            aria-label="Open original"
-            className="icon-button"
-            href={item.url}
-            rel="noreferrer"
-            target="_blank"
-          >
-            <span aria-hidden="true">↗</span>
-          </a>
+          <div className="reader-toolbar-actions">
+            <button
+              aria-label={item.favorite ? "Remove favorite" : "Favorite"}
+              aria-pressed={item.favorite}
+              className="icon-button"
+              disabled={busy}
+              onClick={() => void onFavorite(item)}
+              type="button"
+            >
+              <span aria-hidden="true">★</span>
+            </button>
+            <button
+              aria-haspopup="dialog"
+              aria-label="Edit save"
+              className="icon-button"
+              disabled={busy}
+              onClick={(event) => onEdit(item, event.currentTarget)}
+              type="button"
+            >
+              <span aria-hidden="true">✎</span>
+            </button>
+            <a
+              aria-label="Open original"
+              className="icon-button"
+              href={item.url}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <span aria-hidden="true">↗</span>
+            </a>
+            <button
+              aria-label="Archive"
+              className="icon-button danger-button"
+              disabled={busy}
+              onClick={() => void onDelete(item).then(onBack)}
+              type="button"
+            >
+              <span aria-hidden="true">⌫</span>
+            </button>
+          </div>
         </header>
         <div className="reader-content">
           <div className="reader-meta">
             <span>{readHostname(item.url)} · Saved {formatDate(item.savedAt)}</span>
-            <div>
-              <button aria-label={item.favorite ? "Remove favorite" : "Favorite"} disabled={busy} onClick={() => void onFavorite(item)} type="button">★</button>
-              <button aria-haspopup="dialog" aria-label="Edit save" disabled={busy} onClick={(event) => onEdit(item, event.currentTarget)} type="button">✎</button>
-              <a aria-label="Open original" href={item.url} rel="noreferrer" target="_blank">↗</a>
-              <button aria-label="Archive" disabled={busy} onClick={() => void onDelete(item).then(onBack)} type="button">⌫</button>
-            </div>
           </div>
           <h1 id="reader-title">{label}</h1>
           {item.tags.length > 0 ? <p className="reader-tags">{item.tags.map((tag) => <span key={tag}>#{tag}</span>)}</p> : null}
@@ -2970,25 +3005,6 @@ function ReaderView({
             <p className="reader-source">ResearchPocket keeps the URL and your authored context locally. The original page remains at <a href={item.url} rel="noreferrer" target="_blank">{readHostname(item.url)}</a>.</p>
           </div>
         </div>
-        <footer className="reader-mobile-footer">
-          <span>reader · saved copy</span>
-          <button
-            aria-haspopup="dialog"
-            disabled={busy}
-            onClick={(event) => onEdit(item, event.currentTarget)}
-            type="button"
-          >
-            <span aria-hidden="true">✎</span> edit details
-          </button>
-          <button
-            aria-label="Archive this save"
-            disabled={busy}
-            onClick={() => void onDelete(item).then(onBack)}
-            type="button"
-          >
-            <span aria-hidden="true">⌫</span>
-          </button>
-        </footer>
       </article>
       {expandedImage ? (
         <div
@@ -3031,7 +3047,7 @@ function ReaderView({
           </figure>
         </div>
       ) : null}
-    </div>
+    </section>
   );
 }
 

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -506,21 +506,23 @@ button.local-status:focus-visible .status-copy {
   font-weight: 500;
 }
 
-/*
- * One content plane on a single gutter: every label sits on the left edge and
- * every value starts at --sync-gutter, from the status facts through the
- * pending list to the form. Mixed gutters were what made this read as ragged.
- */
 .sync-section {
-  --sync-gutter: 10rem;
-
   border: 0;
   display: grid;
-  gap: var(--space-6);
+  gap: var(--space-5);
   margin: 0 auto;
-  max-width: 48rem;
-  padding: var(--space-6);
+  max-width: 72rem;
+  padding: 1.5rem;
   width: 100%;
+}
+
+.sync-header {
+  align-items: center;
+  border-bottom: var(--rule) solid var(--color-border-strong);
+  display: flex;
+  gap: var(--space-5);
+  justify-content: space-between;
+  padding-bottom: var(--space-4);
 }
 
 .sync-header h2,
@@ -534,41 +536,89 @@ button.local-status:focus-visible .status-copy {
   margin: 0;
 }
 
-.sync-header > p:not(.eyebrow),
 .welcome-copy,
 .empty-state > p:last-child {
   color: var(--color-text-muted);
   line-height: var(--line-height-body);
 }
 
-.sync-header > p:not(.eyebrow) {
-  font-size: var(--font-size-sm);
-  margin-top: var(--space-3);
+.sync-header > div:first-child > p {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin: var(--space-1) 0 0;
 }
 
 .sync-state {
-  border-bottom: var(--rule) solid var(--color-border);
-  border-top: var(--rule) solid var(--color-border);
+  background: var(--color-surface-raised);
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
   font-size: var(--font-size-xs);
   gap: var(--space-2);
-  margin-top: var(--space-4);
-  min-height: var(--control-height);
-  padding: var(--space-2) 0;
+  min-height: 2rem;
+  padding: 0 var(--space-3);
+}
+
+.sync-layout {
+  align-items: start;
+  display: grid;
+  gap: var(--space-7);
+  grid-template-columns: minmax(19rem, 0.85fr) minmax(0, 1.15fr);
+  min-width: 0;
+}
+
+.sync-connection,
+.sync-pending {
+  border-top: var(--rule) solid var(--color-border-strong);
+  min-width: 0;
+  padding-top: var(--space-3);
+}
+
+.sync-panel-heading,
+.sync-pending-heading {
+  align-items: baseline;
+  display: flex;
+  gap: var(--space-3);
+  justify-content: space-between;
+}
+
+.sync-panel-heading h3,
+.sync-pending-heading h3 {
+  font-size: var(--font-size-md);
+  margin: 0;
+}
+
+.sync-panel-heading > span,
+.sync-pending-heading > span {
+  color: var(--color-text-muted);
+  flex: 0 1 auto;
+  font-size: var(--font-size-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sync-facts {
   display: grid;
   font-size: var(--font-size-xs);
-  margin: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: var(--space-3) 0 0;
   min-width: 0;
 }
 
 .sync-facts > div {
   border-bottom: var(--rule) solid var(--color-border);
   display: grid;
-  gap: var(--space-3);
-  grid-template-columns: var(--sync-gutter) minmax(0, 1fr);
+  gap: var(--space-1);
   padding: var(--space-3) 0;
+}
+
+.sync-facts > div:nth-child(odd) {
+  padding-right: var(--space-4);
+}
+
+.sync-facts > div:nth-child(even) {
+  border-left: var(--rule) solid var(--color-border-subtle);
+  padding-left: var(--space-4);
 }
 
 .sync-facts dt {
@@ -582,7 +632,7 @@ button.local-status:focus-visible .status-copy {
 
 .sync-help,
 .sync-controls > p,
-.sync-form > p {
+.sync-connection-note {
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
 }
@@ -595,15 +645,20 @@ button.local-status:focus-visible .status-copy {
   gap: var(--space-4);
 }
 
-.sync-content {
+.sync-form,
+.sync-controls {
+  margin-top: var(--space-4);
+}
+
+.sync-repository-fields {
   display: grid;
-  gap: var(--space-6);
-  min-width: 0;
+  gap: var(--space-3);
+  grid-template-columns: minmax(0, 1.6fr) minmax(8rem, 0.7fr);
 }
 
 .sync-form .field {
   align-items: start;
-  grid-template-columns: var(--sync-gutter) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .capture-form .field {
@@ -611,20 +666,19 @@ button.local-status:focus-visible .status-copy {
   grid-template-columns: 10rem minmax(0, 1fr);
 }
 
-.sync-form .field > span,
 .capture-form .field > span {
   padding-top: var(--space-3);
 }
 
 .sync-session-choice {
   align-items: start;
-  margin-left: var(--sync-gutter);
+  margin: 0;
 }
 
 .sync-help,
 .sync-error,
 .sync-form > .primary-button {
-  margin-left: var(--sync-gutter);
+  margin-left: 0;
 }
 
 .sync-form > .primary-button {
@@ -646,24 +700,6 @@ button.local-status:focus-visible .status-copy {
   padding: var(--space-2) var(--space-3);
 }
 
-.sync-pending {
-  border-top: var(--rule) solid var(--color-border-strong);
-  min-width: 0;
-  padding-top: var(--space-3);
-}
-
-.sync-pending-heading {
-  align-items: baseline;
-  display: flex;
-  gap: var(--space-3);
-  justify-content: space-between;
-}
-
-.sync-pending-heading h3 {
-  font-size: var(--font-size-md);
-  margin: 0;
-}
-
 .sync-pending-heading > span,
 .sync-pending-help,
 .sync-pending-empty,
@@ -672,10 +708,6 @@ button.local-status:focus-visible .status-copy {
 .sync-change time {
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
-}
-
-.sync-pending-heading > span {
-  flex: 0 0 auto;
 }
 
 .sync-pending-help {
@@ -701,7 +733,7 @@ button.local-status:focus-visible .status-copy {
   border-bottom: var(--rule) solid var(--color-border);
   display: grid;
   gap: var(--space-2) var(--space-4);
-  grid-template-columns: var(--sync-gutter) minmax(0, 1fr) max-content;
+  grid-template-columns: 5.5rem minmax(0, 1fr) max-content;
   padding: var(--space-3) 0;
 }
 
@@ -749,6 +781,12 @@ button.local-status:focus-visible .status-copy {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
+}
+
+@media (max-width: 56rem) {
+  .sync-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .library-section {
@@ -2048,6 +2086,8 @@ footer {
     .command-trigger,
     .local-status,
     .search-clear,
+    .filter-trigger,
+    .filter-close,
     .tag-filter-options button,
     .tag-suggestions button,
     .selected-tags button,
@@ -2058,15 +2098,12 @@ footer {
     .rail-tag-list button,
     .rail-utilities button,
     .rail-heading button,
+    .workspace-rail-toggle,
     .command-results button,
-    .reader-list > header button,
-    .reader-list li button,
-    .reader-meta button,
+    .reader-toolbar button,
     .reader-markdown-image-consent button,
-    .reader-mobile-footer button,
     .item-menu-list button,
-    .masthead-back,
-    .mobile-tag-filter-trigger
+    .masthead-back
   ):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]) {
   background: var(--color-control-pressed);
   border-color: var(--color-accent);
@@ -2075,8 +2112,7 @@ footer {
 
 .app-shell
   :where(
-    .primary-button,
-    .filter-heading button
+    .primary-button
   ):active:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]) {
   background: var(--color-control-primary-pressed);
   border-color: var(--color-control-primary-pressed);
@@ -2095,8 +2131,6 @@ footer {
   .primary-button,
   .secondary-button,
   .command-trigger,
-  .mobile-tag-filter-trigger,
-  .filter-heading button,
   .reader-markdown-image-consent button,
   .reader-image-viewer-close,
   .onboarding-choice
@@ -2110,8 +2144,6 @@ footer {
   .primary-button,
   .secondary-button,
   .command-trigger,
-  .mobile-tag-filter-trigger,
-  .filter-heading button,
   .reader-markdown-image-consent button,
   .reader-image-viewer-close,
   .onboarding-choice
@@ -2128,8 +2160,6 @@ footer {
   .primary-button,
   .secondary-button,
   .command-trigger,
-  .mobile-tag-filter-trigger,
-  .filter-heading button,
   .reader-markdown-image-consent button,
   .reader-image-viewer-close,
   .onboarding-choice
@@ -2139,8 +2169,7 @@ footer {
   border-top: var(--control-press-depth) solid var(--control-edge-color);
 }
 
-.primary-button,
-.filter-heading button {
+.primary-button {
   --control-edge-color: var(--color-inverse);
 }
 
@@ -2153,12 +2182,21 @@ footer {
 }
 
 .masthead {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
   min-height: 3.125rem;
   padding: 0 1.25rem;
 }
 
+.masthead-lead {
+  gap: 0.5rem;
+  min-height: 3.125rem;
+  padding: 0;
+}
+
 .brand-lockup {
-  gap: 0.625rem;
+  gap: 0.5rem;
 }
 
 .brand-context {
@@ -2168,7 +2206,6 @@ footer {
 .masthead-actions,
 .library-title,
 .reader-meta,
-.reader-meta > div,
 .command-footer {
   align-items: center;
   display: flex;
@@ -2176,6 +2213,8 @@ footer {
 
 .masthead-actions {
   gap: 1rem;
+  justify-content: flex-end;
+  padding: 0;
 }
 
 .library-switcher {
@@ -2237,35 +2276,35 @@ kbd {
 .workspace-rail-toggle {
   align-items: center;
   background: transparent;
-  border: var(--rule) solid var(--color-border);
+  border: 0;
   border-radius: var(--radius);
-  color: var(--color-text-soft);
+  color: var(--color-text-muted);
   display: inline-flex;
-  flex: 0 0 auto;
-  height: 1.875rem;
+  flex: 0 0 2rem;
+  font-size: var(--font-size-xs);
+  height: 2rem;
   justify-content: center;
-  min-height: 0;
+  min-height: 2rem;
   padding: 0;
-  width: 1.875rem;
+  width: 2rem;
 }
 
-.rail-toggle-glyph {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1875rem;
+.workspace-rail-toggle svg {
+  fill: none;
+  height: 1rem;
+  stroke: currentColor;
+  stroke-linecap: square;
+  stroke-width: 1.5;
+  width: 1rem;
 }
 
-.rail-toggle-glyph span {
-  background: currentcolor;
-  height: var(--rule);
-  width: 0.75rem;
+.workspace-rail-toggle:hover,
+.workspace-rail-toggle:focus-visible {
+  background: var(--color-surface-muted);
+  color: var(--color-text);
 }
 
 .mobile-actions {
-  display: none;
-}
-
-.mobile-tag-filter-trigger {
   display: none;
 }
 
@@ -2511,8 +2550,16 @@ kbd {
   color: var(--color-text-soft);
 }
 
-.omnibar {
+.library-search-row {
+  align-items: stretch;
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: minmax(0, 1fr) auto;
   margin: 0.625rem 0 0.75rem;
+}
+
+.library-search-row .omnibar {
+  margin: 0;
 }
 
 .omnibar input {
@@ -2520,34 +2567,113 @@ kbd {
   min-height: 2.625rem;
 }
 
+.filter-trigger {
+  align-items: center;
+  background: transparent;
+  border: var(--rule) solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-soft);
+  display: inline-flex;
+  gap: var(--space-2);
+  height: 2.625rem;
+  justify-content: center;
+  min-height: 2.625rem;
+  padding: 0 var(--space-3);
+}
+
+.filter-trigger:hover,
+.filter-trigger:focus-visible,
+.filter-trigger[aria-expanded="true"] {
+  background: var(--color-surface-raised);
+  border-color: var(--color-border-strong);
+  color: var(--color-text);
+}
+
+.filter-trigger svg {
+  fill: none;
+  height: 1rem;
+  stroke: currentColor;
+  stroke-linecap: square;
+  stroke-width: 1.5;
+  width: 1rem;
+}
+
+.filter-trigger-count {
+  align-items: center;
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+  display: inline-flex;
+  font-size: var(--font-size-xs);
+  height: 1.25rem;
+  justify-content: center;
+  min-width: 1.25rem;
+  padding: 0 var(--space-1);
+}
+
 .library-filters {
   background: var(--color-surface);
+  display: grid;
+  gap: var(--space-2);
+  overflow: visible;
   padding: 0.5rem;
+  white-space: normal;
 }
 
-.filter-heading {
+.filter-controls {
   align-items: center;
   display: flex;
-  flex: 0 0 auto;
+  flex-wrap: wrap;
   gap: var(--space-3);
+}
+
+.filter-controls > label:not(.filter-favorite) {
+  flex: 0 0 auto;
+}
+
+.filter-actions {
+  align-items: center;
+  display: flex;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+
+.filter-reset,
+.filter-close {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
   min-height: 2rem;
-  padding-right: var(--space-2);
 }
 
-.filter-heading strong {
-  font-size: var(--font-size-xs);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.filter-reset {
+  padding: 0 var(--space-2);
 }
 
-.filter-heading button {
-  background: var(--color-inverse-surface);
-  border: var(--rule) solid var(--color-inverse-surface);
-  border-radius: var(--radius);
-  color: var(--color-inverse);
-  font-size: var(--font-size-xs);
-  min-height: 1.75rem;
-  padding: 0 0.625rem;
+.filter-close {
+  font-size: 1rem;
+  padding: 0;
+  width: 2rem;
+}
+
+.filter-reset:hover,
+.filter-reset:focus-visible,
+.filter-close:hover,
+.filter-close:focus-visible {
+  color: var(--color-text);
+}
+
+.library-filters .tag-filter-group {
+  border-top: var(--rule) solid var(--color-border-subtle);
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: 10rem minmax(0, 1fr) max-content;
+  padding-top: var(--space-2);
+}
+
+.library-filters .tag-filter-options {
+  min-width: 0;
+  overflow-x: auto;
+  padding-bottom: var(--space-1);
 }
 
 .result-count {
@@ -2606,8 +2732,7 @@ kbd {
 }
 
 .keyboard-footer b,
-.command-footer b,
-.reader-list footer b {
+.command-footer b {
   color: var(--color-text-soft);
 }
 
@@ -2760,101 +2885,59 @@ kbd {
 
 .reader-view {
   background: var(--color-canvas);
-  display: grid;
-  grid-template-columns: 21.25rem minmax(0, 1fr);
-  inset: 3.125rem 0 0;
-  position: fixed;
-  z-index: 40;
-}
-
-.reader-list {
-  border-right: var(--rule) solid var(--color-border);
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.reader-list > header {
-  align-items: center;
-  border-bottom: var(--rule) solid var(--color-border);
-  display: flex;
-  min-height: 3.125rem;
-  padding: 0 1rem;
-}
-
-.reader-list > header button {
-  background: transparent;
-  border: 0;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-}
-
-.reader-list > header span {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-  margin-left: auto;
-}
-
-.reader-list ol {
-  list-style: none;
-  margin: 0;
-  overflow: auto;
-  padding: 0;
-}
-
-.reader-list li {
-  border-bottom: var(--rule) solid var(--color-border-subtle);
-  border-left: 0.125rem solid transparent;
-}
-
-.reader-list li.reader-selected {
-  background: var(--color-surface);
-  border-left-color: var(--color-accent-strong);
-}
-
-.reader-list li button {
-  background: transparent;
-  border: 0;
-  display: grid;
-  gap: 0.2rem;
-  padding: 0.625rem 1rem;
-  text-align: left;
-  width: 100%;
-}
-
-.reader-list li strong {
-  font-size: var(--font-size-sm);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.reader-list li span,
-.reader-list footer {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-}
-
-.reader-list footer {
-  align-items: center;
-  display: flex;
-  gap: 0.75rem;
-  margin-top: auto;
-  min-height: 2.25rem;
-  padding: 0 1rem;
+  min-height: 100%;
+  min-width: 0;
 }
 
 .reader-article {
   min-width: 0;
-  overflow: auto;
+}
+
+.reader-toolbar {
+  align-items: center;
+  background: var(--color-canvas);
+  border-bottom: var(--rule) solid var(--color-border);
+  display: flex;
+  min-height: 3rem;
+  padding: 0 1.25rem;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.reader-back {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--color-text-soft);
+  display: inline-flex;
+  gap: var(--space-2);
+  padding: 0;
+}
+
+.reader-back:hover,
+.reader-back:focus-visible {
+  color: var(--color-text);
+}
+
+.reader-toolbar-actions {
+  align-items: center;
+  display: flex;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+
+.reader-toolbar .icon-button {
+  background: transparent;
+  border-color: transparent;
 }
 
 .reader-content {
   box-sizing: border-box;
   margin-inline: auto;
-  max-width: 80rem;
+  max-width: 74rem;
   min-width: 0;
-  padding: 2.25rem 3rem;
+  padding: 2rem clamp(1.5rem, 4vw, 3rem) 4rem;
   width: 100%;
 }
 
@@ -2864,30 +2947,11 @@ kbd {
   gap: 1rem;
 }
 
-.reader-meta > div {
-  gap: 0.125rem;
-  margin-left: auto;
-}
-
-.reader-meta button,
-.reader-meta a {
-  align-items: center;
-  background: transparent;
-  border: 0;
-  color: var(--color-text-soft);
-  display: inline-flex;
-  font-size: 1rem;
-  height: 2.25rem;
-  justify-content: center;
-  min-height: 2.25rem;
-  text-decoration: none;
-  width: 2.25rem;
-}
-
 .reader-content h1 {
   font-size: 1.625rem;
   letter-spacing: -0.02em;
-  margin: 0;
+  margin: var(--space-3) 0 0;
+  max-width: 32ch;
 }
 
 .reader-tags {
@@ -2908,6 +2972,7 @@ kbd {
   border-left: 0.1875rem solid var(--color-accent);
   margin: 1.25rem 0;
   padding: 0.625rem 0.875rem;
+  max-width: var(--measure);
 }
 
 .reader-note strong {
@@ -2929,6 +2994,7 @@ kbd {
   font-size: 0.875rem;
   gap: 1rem;
   line-height: 1.75;
+  max-width: var(--measure);
   min-width: 0;
   width: 100%;
 }
@@ -3197,11 +3263,6 @@ kbd {
   color: var(--color-text-muted);
 }
 
-.reader-mobile-header,
-.reader-mobile-footer {
-  display: none;
-}
-
 .welcome-card {
   border: 0;
   max-width: 37.5rem;
@@ -3277,8 +3338,16 @@ kbd {
   }
 
   .masthead {
+    display: flex;
+    grid-template-columns: none;
     min-height: 3.25rem;
     padding: 0 1rem;
+  }
+
+  .masthead-lead {
+    min-height: 0;
+    padding: 0;
+    position: static;
   }
 
   /* The product name is the one thing a phone already knows; which screen it
@@ -3321,6 +3390,7 @@ kbd {
     gap: 0.5rem;
     justify-content: flex-end;
     min-width: 0;
+    padding: 0;
   }
 
   .library-switcher {
@@ -3440,18 +3510,6 @@ kbd {
     display: none;
   }
 
-  .mobile-tag-filter-trigger {
-    background: transparent;
-    border: var(--rule) solid var(--color-border);
-    border-radius: var(--radius);
-    color: var(--color-text-soft);
-    display: block;
-    flex: 0 0 auto;
-    font-size: var(--font-size-xs);
-    min-height: 2rem;
-    padding: 0 0.625rem;
-  }
-
   /* A column so the view inside can reach the bottom of the screen. An open
      document ends in a status footer, and a footer that floats halfway up a
      tall blank page reads as the end of the content, not the end of the view. */
@@ -3491,25 +3549,30 @@ kbd {
     z-index: 20;
   }
 
-  .filter-heading {
+  .filter-controls {
     border-bottom: var(--rule) solid var(--color-border-strong);
-    justify-content: space-between;
+    display: grid;
+    gap: 0.625rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     margin-bottom: 0.25rem;
-    min-height: 2.75rem;
-    padding-right: 0;
+    padding-bottom: 0.75rem;
   }
 
-  .filter-heading button {
-    background: var(--color-inverse-surface);
-    border: var(--rule) solid var(--color-inverse-surface);
-    border-radius: var(--radius);
-    color: var(--color-inverse);
-    font-size: var(--font-size-xs);
-    min-height: 2rem;
-    padding: 0 0.625rem;
+  .filter-actions {
+    grid-column: 1 / -1;
+    justify-content: flex-end;
+    margin: 0;
+    order: -1;
   }
 
-  .library-filters > label:not(.filter-favorite),
+  .filter-close {
+    border: var(--rule) solid var(--color-border);
+    color: var(--color-text-soft);
+    min-height: 2.5rem;
+    width: 2.5rem;
+  }
+
+  .filter-controls > label:not(.filter-favorite),
   .library-filters select,
   .tag-filter-group,
   .tag-filter-group > label,
@@ -3517,31 +3580,43 @@ kbd {
     width: 100%;
   }
 
-  .tag-filter-group {
+  .library-filters .tag-filter-group {
     align-items: stretch;
     display: grid;
     gap: 0.625rem;
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .tag-filter-options {
-    align-items: stretch;
-    display: grid;
-    gap: 0;
+  .library-filters .tag-filter-options {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    overflow: visible;
+    padding: 0;
     width: 100%;
   }
 
-  .tag-filter-options button {
-    border: 0;
-    border-bottom: var(--rule) solid var(--color-border-subtle);
-    justify-content: flex-start;
-    min-height: 2.75rem;
-    padding: 0 0.5rem;
-    text-align: left;
-    width: 100%;
+  .library-filters .tag-filter-options button {
+    border: var(--rule) solid var(--color-border);
+    justify-content: center;
+    min-height: 2.5rem;
+    padding: 0 var(--space-3);
+    text-align: center;
+    width: auto;
   }
 
   .omnibar {
     margin: 0;
+    min-height: 2.75rem;
+  }
+
+  .library-search-row {
+    margin: 0;
+  }
+
+  .filter-trigger {
+    height: 2.75rem;
     min-height: 2.75rem;
   }
 
@@ -3611,8 +3686,22 @@ kbd {
   }
 
   .sync-section {
-    grid-template-columns: 1fr;
     padding: 1.25rem 1rem 1.5rem;
+  }
+
+  .sync-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .sync-state {
+    width: 100%;
+  }
+
+  .sync-layout,
+  .sync-repository-fields {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .command-dialog {
@@ -3620,24 +3709,11 @@ kbd {
     max-height: calc(100dvh - 5rem);
   }
 
-  /* An opened save is a pushed screen, not an overlay: the masthead above it
-     stays, carrying the way back and the sync chip, and only the column
-     underneath is replaced. That is the same shell an opened document uses. */
   .reader-view {
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
-    inset: auto;
-    min-height: 0;
-    position: static;
-  }
-
-  .app-shell:has(> .reader-view) > .workspace-layout {
-    display: none;
-  }
-
-  .reader-list {
-    display: none;
+    min-height: 100%;
   }
 
   .reader-article {
@@ -3648,75 +3724,27 @@ kbd {
     overflow: visible;
   }
 
-  .reader-mobile-header {
-    align-items: center;
-    border-bottom: var(--rule) solid var(--color-border-subtle);
-    display: flex;
-    gap: 0.5rem;
+  .reader-toolbar {
     min-height: 2.75rem;
     padding: 0 0.5rem 0 1rem;
+    position: static;
   }
 
-  .reader-mobile-title {
-    flex: 1 1 auto;
-    font-size: var(--font-size-sm);
-    font-weight: 750;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .reader-mobile-header .icon-button {
+  .reader-toolbar .icon-button {
     flex: 0 0 auto;
-    height: 2.75rem;
-    min-height: 2.75rem;
-    width: 2.75rem;
+    height: 2.5rem;
+    min-height: 2.5rem;
+    width: 2.5rem;
   }
 
-  .reader-mobile-header .icon-button[aria-pressed="true"] {
+  .reader-toolbar .icon-button[aria-pressed="true"] {
     background: transparent;
     border-color: transparent;
-  }
-
-  .reader-mobile-footer {
-    align-items: center;
-    border-top: var(--rule) solid var(--color-border-subtle);
-    bottom: 0;
-    background: var(--color-canvas);
-    color: var(--color-text-muted);
-    display: flex;
-    font-size: var(--font-size-xs);
-    gap: 0.75rem;
-    margin-top: auto;
-    min-height: 2.75rem;
-    padding: 0 0.75rem env(safe-area-inset-bottom);
-    position: sticky;
-  }
-
-  .reader-mobile-footer > span {
-    margin-right: auto;
-    padding-left: 0.25rem;
-  }
-
-  .reader-mobile-footer button {
-    background: transparent;
-    border: 0;
-    color: var(--color-text-muted);
-    font-size: var(--font-size-xs);
-    min-height: 2.75rem;
-    padding: 0 0.25rem;
   }
 
   .reader-content {
     flex: 1 1 auto;
     padding: 1.25rem 1.25rem 2rem;
-  }
-
-  /* Favourite, open, edit and archive all moved into the bars above and below,
-     so the desktop action strip has nothing left to show here. */
-  .reader-meta > div {
-    display: none;
   }
 
   .reader-content h1 {


### PR DESCRIPTION
Closes #177

## Summary

- keep the shared desktop rail and masthead present in saved-item, Sync, and Settings views
- place the sidebar toggle before the monogram and wordmark as one compact header cluster
- preserve the newer collapsed glyph rail and add a reachable Sync destination to it
- add a dedicated Filters control immediately after search with an applied-filter count
- remove the redundant filter heading and simplify filter, tag, reader, and Sync surfaces

## User-visible impact

Saved items now open inside the normal owner workspace instead of replacing it. Sync uses the same navigation shell, the sidebar control no longer floats at the rail seam, filters are directly accessible from search, and the Sync surface is materially less dense.

## Protocol and privacy impact

None. This changes only owner-app presentation and navigation. It does not alter sync transport, credential handling, CRDT state, persistence, publication, or exported schemas.

## Verification

- `cargo fmt --all -- --check`
- `bun run test` — 30 passed
- `bun run typecheck`
- `bun run check:design`
- `bun run wasm`
- `bunx vite build`
- `bun run check:dist`
- `git diff --check origin/main...HEAD`

## UI evidence

Verified in a live Chromium session with no page console errors:

- 1440 × 900 library with expanded sidebar
- 1440 × 900 library with collapsed glyph rail
- 1440 × 900 saved-item reader with collapsed glyph rail
- 1440 × 900 Sync with collapsed glyph rail
- 320 × 740 library and filter surface
- 320 × 740 Sync surface
