### PR TITLE
Give the reader a measure it can keep

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -99,7 +99,25 @@ const LIBRARY_MODE_STORAGE_KEY = "researchpocket.ui.library-mode";
 const RAIL_COLLAPSED_STORAGE_KEY = "researchpocket.ui.rail-collapsed";
 const THEME_STORAGE_KEY = "researchpocket.ui.theme";
 const IMAGE_BACKGROUND_STORAGE_KEY = "researchpocket.ui.image-background";
+const READER_MEASURE_STORAGE_KEY = "researchpocket.ui.reader-measure";
 const DEFAULT_IMAGE_BACKGROUND = "#ffffff";
+
+/**
+ * How wide the reader lets a line of text run. The values are the text column
+ * only — the stylesheet adds the gutters back — so they read as a measure and
+ * not as a pane width. `100%` is the one that opts out: it always resolves
+ * wider than the column, so the cap never binds.
+ */
+const READER_MEASURES = [
+  { id: "narrow", label: "Narrow", measure: "34rem" },
+  { id: "medium", label: "Medium", measure: "42rem" },
+  { id: "wide", label: "Wide", measure: "52rem" },
+  { id: "full", label: "Full width", measure: "100%" },
+] as const;
+
+type ReaderMeasure = (typeof READER_MEASURES)[number]["id"];
+
+const DEFAULT_READER_MEASURE: ReaderMeasure = "medium";
 
 const DEFAULT_THEME: ThemeColors = {
   text: "#f5f1e9",
@@ -213,6 +231,9 @@ export function App() {
   const [theme, setTheme] = useState<ThemeColors>(() => readThemePreference());
   const [imageBackground, setImageBackground] = useState(
     () => readImageBackgroundPreference(),
+  );
+  const [readerMeasure, setReaderMeasure] = useState<ReaderMeasure>(() =>
+    readReaderMeasurePreference(),
   );
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [visibleLimit, setVisibleLimit] = useState(LIST_BATCH_SIZE);
@@ -373,6 +394,27 @@ export function App() {
       // The preference remains active for this tab when storage is unavailable.
     }
   }, [imageBackground]);
+
+  useEffect(() => {
+    const choice = READER_MEASURES.find(({ id }) => id === readerMeasure);
+    const root = document.documentElement;
+    // The default lives in tokens.css, so choosing it clears the override
+    // rather than restating the value in two places.
+    if (choice && readerMeasure !== DEFAULT_READER_MEASURE) {
+      root.style.setProperty("--reader-measure", choice.measure);
+    } else {
+      root.style.removeProperty("--reader-measure");
+    }
+    try {
+      if (readerMeasure === DEFAULT_READER_MEASURE) {
+        window.localStorage.removeItem(READER_MEASURE_STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(READER_MEASURE_STORAGE_KEY, readerMeasure);
+      }
+    } catch {
+      // The preference remains active for this tab when storage is unavailable.
+    }
+  }, [readerMeasure]);
 
   useEffect(() => {
     function handleShortcut(event: KeyboardEvent) {
@@ -1370,9 +1412,11 @@ export function App() {
           onDensityChange={setDensity}
           onImageBackgroundChange={setImageBackground}
           onProfilesChanged={refreshProfiles}
+          onReaderMeasureChange={setReaderMeasure}
           onSwitchLibrary={switchLibrary}
           onThemeChange={setTheme}
           profiles={profiles}
+          readerMeasure={readerMeasure}
           theme={theme}
         />
 
@@ -2057,9 +2101,11 @@ function SettingsPanel({
   onDensityChange,
   onImageBackgroundChange,
   onProfilesChanged,
+  onReaderMeasureChange,
   onSwitchLibrary,
   onThemeChange,
   profiles,
+  readerMeasure,
   theme,
 }: {
   activeProfileId: string | null;
@@ -2069,9 +2115,11 @@ function SettingsPanel({
   onDensityChange: (density: Density) => void;
   onImageBackgroundChange: (color: string) => void;
   onProfilesChanged: () => Promise<void>;
+  onReaderMeasureChange: (measure: ReaderMeasure) => void;
   onSwitchLibrary: (profileId: string) => Promise<void>;
   onThemeChange: (theme: ThemeColors) => void;
   profiles: LibraryProfile[];
+  readerMeasure: ReaderMeasure;
   theme: ThemeColors;
 }) {
   const selectedPreset =
@@ -2113,6 +2161,26 @@ function SettingsPanel({
               }
               type="checkbox"
             />
+          </label>
+          <label className="setting-row" htmlFor="reader-measure">
+            <span>
+              <strong>Reading width</strong>
+              <small>
+                How far a line of text runs in an opened save. Anything short of
+                full width is centered in the column.
+              </small>
+            </span>
+            <select
+              id="reader-measure"
+              onChange={(event) =>
+                onReaderMeasureChange(event.target.value as ReaderMeasure)
+              }
+              value={readerMeasure}
+            >
+              {READER_MEASURES.map(({ id, label }) => (
+                <option key={id} value={id}>{label}</option>
+              ))}
+            </select>
           </label>
           <fieldset className="theme-editor">
             <legend>Color theme</legend>
@@ -4065,6 +4133,17 @@ function readImageBackgroundPreference() {
   } catch {
     return DEFAULT_IMAGE_BACKGROUND;
   }
+}
+
+function readReaderMeasurePreference(): ReaderMeasure {
+  try {
+    const stored = window.localStorage.getItem(READER_MEASURE_STORAGE_KEY);
+    const match = READER_MEASURES.find(({ id }) => id === stored);
+    if (match) return match.id;
+  } catch {
+    // Invalid or unavailable storage falls back to the shipped measure.
+  }
+  return DEFAULT_READER_MEASURE;
 }
 
 function isThemeColors(value: unknown): value is ThemeColors {

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -2932,12 +2932,17 @@ kbd {
   border-color: transparent;
 }
 
+/* The measure is the text column alone. The gutters sit outside it, so the cap
+   has to carry both or a chosen width would arrive that much narrower than it
+   reads. Full width is `--reader-measure: 100%`, which resolves wider than the
+   column can be, so the cap simply never binds. */
 .reader-content {
+  --reader-gutter: clamp(1.5rem, 4vw, 3rem);
   box-sizing: border-box;
   margin-inline: auto;
-  max-width: 74rem;
+  max-width: calc(var(--reader-measure) + var(--reader-gutter) * 2);
   min-width: 0;
-  padding: 2rem clamp(1.5rem, 4vw, 3rem) 4rem;
+  padding: 2rem var(--reader-gutter) 4rem;
   width: 100%;
 }
 
@@ -3743,8 +3748,9 @@ kbd {
   }
 
   .reader-content {
+    --reader-gutter: 1.25rem;
     flex: 1 1 auto;
-    padding: 1.25rem 1.25rem 2rem;
+    padding: 1.25rem var(--reader-gutter) 2rem;
   }
 
   .reader-content h1 {
@@ -4014,6 +4020,13 @@ kbd {
   font-size: var(--font-size-xs);
   margin-top: 0.25rem;
   max-width: 44ch;
+}
+
+/* Selects are full-width by default, which in a space-between row would push
+   the label off the left edge. Here they are a control, not a field. */
+.setting-row select {
+  flex: 0 0 auto;
+  width: 10rem;
 }
 
 .setting-row input {

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -103,6 +103,7 @@
   --control-press-offset: 0.0625rem;
   --measure: 72ch;
   --page-width: 100rem;
+  --reader-measure: 42rem;
   --rule: 1px;
   --radius: 0.125rem;
 }


### PR DESCRIPTION
`.reader-content` was capped at `74rem` and centred with `margin-inline: auto`. The sidebar takes `14rem`, so the workspace column is roughly `1216px` on a 1440px screen — the cap bought 16px of margin a side, and on anything narrower it bought none at all. The centring rule was there; it just never had room to do anything. Meanwhile `74rem` is about four times a readable measure, so even where it did bind the result was a slab.

## Changes

**The cap is a measure plus its gutters.** `--reader-measure` is the text column alone, so the value reads as a measure rather than as a pane width. The stylesheet adds the padding back through a local `--reader-gutter`, which the mobile block already overrides — one number, correct at both widths:

```css
.reader-content {
  --reader-gutter: clamp(1.5rem, 4vw, 3rem);
  max-width: calc(var(--reader-measure) + var(--reader-gutter) * 2);
  padding: 2rem var(--reader-gutter) 4rem;
}
```

**Settings → Appearance → Reading width.** Narrow (`34rem`), Medium (`42rem`, the new default), Wide (`52rem`), Full width. It follows the transparent-image-background preference exactly: stored in `localStorage`, written to `document.documentElement` as a custom property, and *cleared* rather than restated when it is the default, so `tokens.css` stays the single place the shipped value lives.

**Full width is `100%`.** It always resolves wider than the column can be, so the cap never binds. Whoever preferred the edge-to-edge reading pane still has it — one choice away, rather than as the only option.

**`.setting-row select`.** `base.css` gives selects `width: 100%`; in a `space-between` row that would push the label off the left edge. Fixed to `10rem`.

## Verification

- `npm test` — 30 pass, 0 fail
- `npm run check:design` — passed
- `npm run typecheck` — clean apart from the pre-existing `../generated/research_domain` error, which needs `npm run wasm`

`wasm-bindgen-cli` will not build on my machine — there is no MSVC linker installed — so the `npm run build` chain runs in CI only. CI covers it.

**Still worth a human eye:** I have not seen this rendered. Medium is a judgement call about what a comfortable line looks like in TX-02 at `0.875rem`; if it reads too tight or too loose, the fix is one number in `tokens.css`.
