### PR TITLE
Take the h2 fix for unbounded empty DATA frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,9 +1137,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
`Dependency audit` is failing on `main`, and so on every open PR. [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) — *h2 unbounded empty DATA frames* — was published on 2026-08-17 against `h2` 0.4.15.

Unlike the five exceptions in `.cargo/audit.toml`, this one has a patched release, so it is a bump and not another entry in the ignore list.

## Changes

`h2` 0.4.15 → 0.4.16. It reaches us through `reqwest` 0.13.4 by way of `hyper`, which is the fetch path the CLI uses:

```
h2 v0.4.16
├── hyper v1.10.1
│   ├── hyper-rustls v0.27.9
│   │   └── reqwest v0.13.4
│   │       └── research v2.2.1
│   ├── hyper-util v0.1.20
│   └── reqwest v0.13.4
└── reqwest v0.13.4
```

A hostile server can hold a connection open sending empty DATA frames the client never accounts for.

## Only two lines move

`cargo update -p h2` did the bump, but it also re-pointed six unrelated crates — `rustix`, `tempfile`, `rustls-native-certs`, `socket2` and two others — from `windows-sys` 0.61.2 down to 0.52.0. That is dedup churn against a version already present in the lock, and a silent downgrade of the Windows bindings has no business riding along with a security fix. So the version and checksum are the only edit, and `cargo metadata --locked` accepts the result, which it would refuse to do if the lockfile needed anything further.

## Verification

`cargo metadata --format-version 1 --locked` — passes.

Nothing else could run here: there is no MSVC linker on this machine, so `cargo check`, `cargo test` and `cargo audit` all fail to link locally. CI is the check that matters, and `Dependency audit` on this branch is the one to read.
