### PR TITLE
Repair native sync restore and release 2.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "research"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "base64",
  "chrono",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "research-domain"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "base64",
  "chrono",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "research-store"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 rust-version = "1.94"
 keywords = ["bookmarks", "reading-list", "local-first", "knowledge", "cli"]
@@ -22,8 +22,8 @@ crossterm = "0.29.0"
 directories = "6.0.0"
 ratatui = { version = "0.30.2", default-features = false, features = ["crossterm_0_29"] }
 reqwest = { version = "0.13.4", features = ["json"] }
-research-domain = { version = "=2.2.1", path = "crates/research-domain" }
-research-store = { version = "=2.2.1", path = "crates/research-store" }
+research-domain = { version = "=2.2.2", path = "crates/research-domain" }
+research-store = { version = "=2.2.2", path = "crates/research-store" }
 scraper = "0.27.0"
 serde = "1.0.228"
 serde_json = "1.0.150"

--- a/crates/research-domain/Cargo.toml
+++ b/crates/research-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-domain"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]

--- a/crates/research-store/Cargo.toml
+++ b/crates/research-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "research-store"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 rust-version = "1.94"
 authors = ["KorigamiK <korigamik.is-a.dev>"]
@@ -11,7 +11,7 @@ description = "Local SQLite projection, import, enrichment, and outbox for Resea
 [dependencies]
 base64 = "0.22.1"
 chrono = { version = "0.4.45", default-features = false, features = ["clock", "serde"] }
-research-domain = { version = "=2.2.1", path = "../research-domain" }
+research-domain = { version = "=2.2.2", path = "../research-domain" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"

--- a/crates/research-store/src/sync.rs
+++ b/crates/research-store/src/sync.rs
@@ -3,9 +3,9 @@ use std::collections::BTreeMap;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use chrono::{DateTime, FixedOffset};
 use research_domain::{
-    CheckpointArtifact, CheckpointCoverage, CoverageInterval, Library, LibraryGenesis,
-    UpdateEnvelope, coverage_contains, create_checkpoint, unpack_operation_pack,
-    validate_checkpoint,
+    CanonicalProjection, CheckpointArtifact, CheckpointCoverage, CoverageInterval, Library,
+    LibraryGenesis, UpdateEnvelope, coverage_contains, create_checkpoint,
+    unpack_operation_pack, validate_checkpoint,
 };
 use sqlx::{Row, SqliteConnection};
 
@@ -403,6 +403,57 @@ impl V2Store {
         }
     }
 
+    /// Re-offer persisted envelopes whose predecessors may have arrived later.
+    ///
+    /// An earlier sync can have observed every remote blob while leaving a
+    /// reverse-ordered dependency chain deferred. Running this independently of
+    /// download discovery lets the next sync heal that local intermediate state.
+    pub async fn retry_deferred_batches(&self) -> StoreResult<u64> {
+        let deferred: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM deferred_batches")
+            .fetch_one(&self.pool)
+            .await?;
+        if deferred == 0 {
+            return Ok(0);
+        }
+
+        let local_device_id = self.meta("device_id").await?;
+        let peer_id = peer_id_for_device(&local_device_id)?;
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await?;
+        let result = async {
+            let state = sqlx::query(
+                "SELECT snapshot, snapshot_sha256 FROM canonical_state WHERE singleton = 1",
+            )
+            .fetch_one(&mut *connection)
+            .await?;
+            let snapshot: Vec<u8> = state.try_get("snapshot")?;
+            let expected_snapshot_sha256: String = state.try_get("snapshot_sha256")?;
+            if sha256_hex(&snapshot) != expected_snapshot_sha256 {
+                return Err(StoreError::InvalidStore(
+                    "canonical snapshot checksum mismatch".into(),
+                ));
+            }
+            let library = Library::from_snapshot(&snapshot, peer_id)?;
+            let before_projection = library.canonical_projection()?;
+            let remaining = replay_deferred_batches(&mut connection, &library).await?;
+            persist_library_state(&mut connection, &library, &before_projection).await?;
+            Ok(remaining)
+        }
+        .await;
+        match result {
+            Ok(remaining) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(remaining)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+
     pub async fn record_outbox_attempt(
         &self,
         path: &str,
@@ -588,48 +639,15 @@ async fn apply_remote_batch(
     }
     let library = Library::from_snapshot(&snapshot, peer_id)?;
     let before_projection = library.canonical_projection()?;
-    let incoming_pending = library.import_envelope_has_pending(envelope)?;
-    // A Loro snapshot does not retain an update whose causal predecessor was
-    // absent when that snapshot was exported. Receipted immutable envelopes do
-    // retain it. Replay only the explicitly deferred tail; once a predecessor
-    // arrives, previously deferred effects materialize in this transaction.
-    let deferred = sqlx::query(
-        "SELECT b.device_id, b.sequence, b.envelope_json FROM deferred_batches d \
-         JOIN batches b USING (device_id, sequence) \
-         ORDER BY b.device_id ASC, b.sequence ASC",
-    )
-    .fetch_all(&mut *connection)
-    .await?;
-    for row in deferred {
-        let device_id: String = row.try_get("device_id")?;
-        let sequence: String = row.try_get("sequence")?;
-        let stored_json: String = row.try_get("envelope_json")?;
-        let stored: UpdateEnvelope = serde_json::from_str(&stored_json)?;
-        if !library.import_envelope_has_pending(&stored)? {
-            sqlx::query("DELETE FROM deferred_batches WHERE device_id = ? AND sequence = ?")
-                .bind(device_id)
-                .bind(sequence)
-                .execute(&mut *connection)
-                .await?;
+    let mut incoming_pending = library.import_envelope_has_pending(envelope)?;
+    replay_deferred_batches(connection, &library).await?;
+    if incoming_pending {
+        incoming_pending = library.import_envelope_has_pending(envelope)?;
+        if !incoming_pending {
+            replay_deferred_batches(connection, &library).await?;
         }
     }
-    let new_snapshot = library.export_snapshot()?;
-    let projection = library.canonical_projection()?;
-    let now = now_rfc3339();
-    for (item_id, item) in &projection.items {
-        if before_projection.items.get(item_id) != Some(item) {
-            persist_item_projection(connection, item_id, item).await?;
-        }
-    }
-    sqlx::query(
-        "UPDATE canonical_state SET snapshot = ?, snapshot_sha256 = ?, updated_at = ? \
-         WHERE singleton = 1",
-    )
-    .bind(&new_snapshot)
-    .bind(sha256_hex(&new_snapshot))
-    .bind(&now)
-    .execute(&mut *connection)
-    .await?;
+    let now = persist_library_state(connection, &library, &before_projection).await?;
     sqlx::query(
         "INSERT INTO batches \
          (device_id, sequence, payload_sha256, protocol_version, library_id, path, \
@@ -657,6 +675,83 @@ async fn apply_remote_batch(
         disposition: RemoteBatchDisposition::Applied,
         acknowledged_outbox: false,
     })
+}
+
+/// Retry the deferred set in rounds because one deferred envelope can satisfy
+/// another that sorted before it. A round with no reduction is the fixed point
+/// for the currently available history.
+async fn replay_deferred_batches(
+    connection: &mut SqliteConnection,
+    library: &Library,
+) -> StoreResult<u64> {
+    let rows = sqlx::query(
+        "SELECT b.device_id, b.sequence, b.envelope_json FROM deferred_batches d \
+         JOIN batches b USING (device_id, sequence) \
+         ORDER BY b.device_id ASC, b.sequence ASC",
+    )
+    .fetch_all(&mut *connection)
+    .await?;
+    let mut pending = rows
+        .into_iter()
+        .map(|row| {
+            let device_id: String = row.try_get("device_id")?;
+            let sequence: String = row.try_get("sequence")?;
+            let envelope_json: String = row.try_get("envelope_json")?;
+            let envelope = serde_json::from_str(&envelope_json)?;
+            StoreResult::Ok((device_id, sequence, envelope))
+        })
+        .collect::<StoreResult<Vec<_>>>()?;
+
+    loop {
+        if pending.is_empty() {
+            return Ok(0);
+        }
+        let previous_count = pending.len();
+        let mut unresolved = Vec::new();
+        for (device_id, sequence, envelope) in pending {
+            if library.import_envelope_has_pending(&envelope)? {
+                unresolved.push((device_id, sequence, envelope));
+            } else {
+                sqlx::query(
+                    "DELETE FROM deferred_batches WHERE device_id = ? AND sequence = ?",
+                )
+                .bind(device_id)
+                .bind(sequence)
+                .execute(&mut *connection)
+                .await?;
+            }
+        }
+        if unresolved.len() == previous_count {
+            return u64::try_from(unresolved.len())
+                .map_err(|_| StoreError::NumericRange("deferred batch count"));
+        }
+        pending = unresolved;
+    }
+}
+
+async fn persist_library_state(
+    connection: &mut SqliteConnection,
+    library: &Library,
+    before_projection: &CanonicalProjection,
+) -> StoreResult<String> {
+    let new_snapshot = library.export_snapshot()?;
+    let projection = library.canonical_projection()?;
+    let now = now_rfc3339();
+    for (item_id, item) in &projection.items {
+        if before_projection.items.get(item_id) != Some(item) {
+            persist_item_projection(connection, item_id, item).await?;
+        }
+    }
+    sqlx::query(
+        "UPDATE canonical_state SET snapshot = ?, snapshot_sha256 = ?, updated_at = ? \
+         WHERE singleton = 1",
+    )
+    .bind(&new_snapshot)
+    .bind(sha256_hex(&new_snapshot))
+    .bind(&now)
+    .execute(&mut *connection)
+    .await?;
+    Ok(now)
 }
 
 pub(crate) async fn build_checkpoint_candidate(

--- a/crates/research-store/tests/sync_contract.rs
+++ b/crates/research-store/tests/sync_contract.rs
@@ -680,3 +680,143 @@ async fn remote_replay_is_exact_idempotent_and_convergent() {
         second_projection
     );
 }
+
+#[tokio::test]
+async fn reverse_ordered_dependency_chain_retries_to_a_fixed_point() {
+    let root = tempfile::tempdir().expect("temporary test root");
+    let base = V2Store::init(root.path().join("base"))
+        .await
+        .expect("base store");
+    let first_peer = V2Store::init(root.path().join("first-peer"))
+        .await
+        .expect("first peer");
+    let second_peer = V2Store::init(root.path().join("second-peer"))
+        .await
+        .expect("second peer");
+    let first_id = first_peer
+        .sync_identity()
+        .await
+        .expect("first identity")
+        .device_id;
+    let second_id = second_peer
+        .sync_identity()
+        .await
+        .expect("second identity")
+        .device_id;
+    let (leaf, middle) = if first_id < second_id {
+        (&first_peer, &second_peer)
+    } else {
+        (&second_peer, &first_peer)
+    };
+    let identity = base.sync_identity().await.expect("base identity");
+    for peer in [leaf, middle] {
+        peer.adopt_library_id_if_pristine(&identity.library_id)
+            .await
+            .expect("adopt base library");
+    }
+
+    let item = base
+        .create_item(CreateItemRequest {
+            url: "https://example.com/dependency-chain".into(),
+            title: Some("Base".into()),
+            excerpt: None,
+            favorite: false,
+            language: None,
+            saved_at: None,
+            note: String::new(),
+            tags: Vec::new(),
+        })
+        .await
+        .expect("create base item");
+    let predecessor = base.pending_batches().await.expect("base outbox").remove(0);
+    middle
+        .receive_remote_batch(
+            &predecessor.path,
+            &"a".repeat(40),
+            predecessor.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("middle receives predecessor");
+    middle
+        .edit_item(EditItemRequest {
+            item_id: item.id.clone(),
+            title: Some(OptionalTextUpdate::Set("Middle".into())),
+            ..EditItemRequest::default()
+        })
+        .await
+        .expect("create middle operation");
+    let middle_batch = middle
+        .pending_batches()
+        .await
+        .expect("middle outbox")
+        .remove(0);
+
+    leaf.receive_remote_batch(
+        &predecessor.path,
+        &"a".repeat(40),
+        predecessor.envelope_json.as_bytes(),
+    )
+    .await
+    .expect("leaf receives predecessor");
+    leaf.receive_remote_batch(
+        &middle_batch.path,
+        &"b".repeat(40),
+        middle_batch.envelope_json.as_bytes(),
+    )
+    .await
+    .expect("leaf receives middle operation");
+    leaf.edit_item(EditItemRequest {
+        item_id: item.id.clone(),
+        favorite: Some(true),
+        ..EditItemRequest::default()
+    })
+    .await
+    .expect("create leaf operation");
+    let leaf_batch = leaf.pending_batches().await.expect("leaf outbox").remove(0);
+
+    let receiver = V2Store::init(root.path().join("receiver"))
+        .await
+        .expect("receiver store");
+    receiver
+        .adopt_library_id_if_pristine(&identity.library_id)
+        .await
+        .expect("adopt receiver library");
+    receiver
+        .receive_remote_batch(
+            &leaf_batch.path,
+            &"c".repeat(40),
+            leaf_batch.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("receive leaf first");
+    receiver
+        .receive_remote_batch(
+            &middle_batch.path,
+            &"b".repeat(40),
+            middle_batch.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("receive middle second");
+    assert_eq!(receiver.retry_deferred_batches().await.expect("retry"), 2);
+
+    receiver
+        .receive_remote_batch(
+            &predecessor.path,
+            &"a".repeat(40),
+            predecessor.envelope_json.as_bytes(),
+        )
+        .await
+        .expect("receive predecessor last");
+    assert_eq!(receiver.retry_deferred_batches().await.expect("retry"), 0);
+    assert_eq!(
+        receiver
+            .status()
+            .await
+            .expect("receiver status")
+            .deferred_updates,
+        0
+    );
+    let restored = receiver.item(&item.id).await.expect("restored item");
+    assert_eq!(restored.title.as_deref(), Some("Middle"));
+    assert!(restored.favorite);
+}

--- a/docs/releases/v2.2.2.md
+++ b/docs/releases/v2.2.2.md
@@ -1,0 +1,74 @@
+# ResearchPocket 2.2.2
+
+ResearchPocket 2.2.2 fixes native restoration of a valid private library when
+several cross-device updates arrive in reverse causal order. The hosted owner
+app already restored this history correctly; the native CLI and TUI now reach
+the same converged library.
+
+## Install
+
+With Rust installed:
+
+```sh
+cargo install --locked --force research
+```
+
+Or download the verified archive for Linux, macOS, or Windows from the GitHub
+release and check it against `SHA256SUMS`.
+
+## What changed
+
+- **Native deferred updates retry to a fixed point.** A deferred update can
+  depend on another deferred update that sorts after it. Native persistence now
+  re-offers the set in bounded rounds until no additional predecessor can be
+  satisfied instead of treating one unsuccessful pass as missing history.
+- **Interrupted restores repair themselves after upgrade.** A failed native
+  restore may already have recorded every immutable remote object. A later sync
+  now retries those persisted deferred envelopes even when there is nothing to
+  download, then continues with normal aggregate synchronization.
+- **Incomplete histories still fail closed.** If a predecessor is genuinely
+  absent after replay reaches a fixed point, synchronization stops before any
+  local update is uploaded and keeps the same integrity error.
+
+The fix was verified against a production-sized private repository that exposed
+the failure and with a three-device contract test delivering a grandchild,
+child, and predecessor in reverse order.
+
+## Upgrade an affected library
+
+Revoke any credential that has been exposed in terminal output or shell history,
+upgrade the native client, and run a normal synchronization cycle:
+
+```sh
+cargo install --locked --force research
+research --version
+research sync run
+```
+
+The expected version is `research 2.2.2`. Do not reconnect or delete the local
+library after the earlier integrity error. The next sync reuses its durable
+receipts and repairs the deferred projection without downloading or rewriting
+the immutable history again.
+
+This release does not change the synchronization protocol, SQLite schema,
+operation-pack format, checkpoint format, aggregate generation, or repository
+layout. Existing native and hosted clients remain wire-compatible.
+
+## GitHub release archives
+
+| Platform | Release asset |
+| --- | --- |
+| Linux GNU/glibc x86-64 (glibc 2.35 or newer) | `research-v2.2.2-linux-amd64.tar.gz` |
+| Windows x86-64 | `research-v2.2.2-windows-amd64.zip` |
+| macOS Intel | `research-v2.2.2-macos-amd64.tar.gz` |
+| macOS Apple Silicon | `research-v2.2.2-macos-arm64.tar.gz` |
+
+The archives remain unsigned. Verify the selected file with `SHA256SUMS`, or
+build the exact tag with the pinned toolchain:
+
+```sh
+git clone --branch v2.2.2 --depth 1 \
+  https://github.com/ResearchPocket/researchpocket.github.io.git
+cd researchpocket.github.io
+cargo build --locked --release
+```

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -830,7 +830,7 @@ async fn pull_remote(
             }
         }
     }
-    if store.status().await?.deferred_updates > 0 {
+    if store.retry_deferred_batches().await? > 0 {
         return Err(SyncError::Integrity(
             "remote operations have missing causal dependencies".into(),
         ));

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "research-pocket-web",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-pocket-web",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
         "highlight.js": "11.11.1",
         "idb": "8.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-pocket-web",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "type": "module",
   "scripts": {
     "dev": "npm run wasm && vite",


### PR DESCRIPTION
## Summary

- retry deferred protocol-v1 envelopes to a fixed point when causal predecessors arrive out of path order
- repair already-observed deferred rows on the next sync so failed native restores self-heal after upgrade
- keep genuinely incomplete histories fail-closed before upload
- add a three-device reverse-order convergence contract test
- bump the Rust workspace and hosted app to 2.2.2 with matching release notes

Refs #181

## User-visible impact

A native CLI or TUI restore that previously stopped with `remote operations have missing causal dependencies` can be retried after upgrading. The existing local library and immutable remote history are reused; reconnecting, deleting local state, or rewriting the repository is not required.

## Protocol and privacy impact

No wire-format, schema, operation-pack, checkpoint, aggregate, credential, publication, or repository-layout change. Missing predecessors still stop synchronization before local updates upload.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-targets --all-features`
- `cargo audit --deny warnings`
- `cargo build --locked --release`
- `npm ci` in `web/`
- `npm run verify` in `web/`
- reproduced and repaired the affected production-sized private repository with 1,026 items, zero deferred updates, and zero pending uploads
- browser-WASM convergence compiled locally; runtime execution is left to CI because this machine has no WebDriver